### PR TITLE
Update model-b and c for compatibility ESPHome 2025.2

### DIFF
--- a/esphome/model-b.yaml
+++ b/esphome/model-b.yaml
@@ -20,13 +20,13 @@ substitutions:
 
 #Set up ESPHome
 esphome:
-  name: watermeter
-  platform: ESP8266
-  board: d1_mini
-  
+  name: watermeter  
   project:
     name: dwainscheeren.watermeterkit
     version: "${watermeterkit_version}"
+
+esp8266:
+  board: d1_mini
 
 #WiFi Settings
 wifi:

--- a/esphome/model-c.yaml
+++ b/esphome/model-c.yaml
@@ -20,13 +20,13 @@ substitutions:
 
 #Set up ESPHome
 esphome:
-  name: watermeter
-  platform: ESP8266
-  board: d1_mini
-  
+  name: watermeter  
   project:
     name: dwainscheeren.watermeterkit
     version: "${watermeterkit_version}"
+
+esp8266:
+  board: d1_mini
 
 #WiFi Settings
 wifi:


### PR DESCRIPTION
As was done in https://github.com/dwainscheeren/watermeterkit/commit/9a852849cb65abfc2b9bf080c77ef9b685c12494 for model-a.

I verified my model-b works, but I cannot test the model-c. However as that part of the yaml is exactly the same I assume it works.